### PR TITLE
Eliminate oh my zsh zshrc var

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ following tasks:
 | `oh_my_zsh_zshrc_template` | `templates/zshrc.zsh-template.j2` | The template used to create the user's `.zshrc` file when `oh_my_zsh_zshrc_create` is `true`. |
 | `oh_my_zsh_zshrc_backup` | `true` | Whether or not to create backup the existing `.zshrc` files when the role changes it. |
 | `oh_my_zsh_zshrc` | (see below) | List of variables used in `templates/zshrc.zsh-template.j2` or your custom template. |
-| `oh_my_zsh_zshrc.zsh_theme` | `robbyrussell` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.case_sensitive` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.hyphen_insensitive` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.disable_auto_update` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.update_zsh_days` | `13` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.disable_ls_colors` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.disable_auto_title` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.enable_correction` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.completion_waiting_dots` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.disable_untracked_files_dirty` | `false` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.hist_stamps` | `mm/dd/yyyy` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.zsh_custom` | `$ZSH/custom` | See `templates/zshrc.zsh-template`. |
-| `oh_my_zsh_zshrc.plugins` | `[]` | A list of Oh My Zsh plugins to enable. |
+| `oh_my_zsh_zsh_theme` | `robbyrussell` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_case_sensitive` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_hyphen_insensitive` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_disable_auto_update` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_update_zsh_days` | `13` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_disable_ls_colors` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_disable_auto_title` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_enable_correction` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_completion_waiting_dots` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_disable_untracked_files_dirty` | `false` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_hist_stamps` | `mm/dd/yyyy` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_zsh_custom` | `$ZSH/custom` | See `templates/zshrc.zsh-template`. |
+| `oh_my_zsh_plugins` | `[]` | A list of Oh My Zsh plugins to enable. |
 
 ## Role task files
 
@@ -124,4 +124,7 @@ This task only runs when `oh_my_zsh_zshrc_create` is set to `false`.
             # Only create `.zshrc` for user 'lorem'; item.settings will be
             # appended to `.zshrc` for the user 'ipsum'.
             oh_my_zsh_zshrc_create: "{{ (item.name == 'lorem') | ternary(true, false) }}"
+            oh_my_zsh_plugins:
+              - "autojump"
+              - "git"
           with_items: "{{ users }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,17 +18,16 @@ oh_my_zsh_install_directory: ".oh-my-zsh"
 oh_my_zsh_zshrc_create: true
 oh_my_zsh_zshrc_template: "templates/zshrc.zsh-template.j2"
 oh_my_zsh_zshrc_backup: true
-oh_my_zsh_zshrc:
-  zsh_theme: "robbyrussell"
-  case_sensitive: false
-  hyphen_insensitive: false
-  disable_auto_update: false
-  update_zsh_days: 13
-  disable_ls_colors: false
-  disable_auto_title: false
-  enable_correction: false
-  completion_waiting_dots: false
-  disable_untracked_files_dirty: false
-  hist_stamps: "mm/dd/yyyy"
-  zsh_custom: "$ZSH/custom"
-  plugins: []
+oh_my_zsh_zsh_theme: "robbyrussell"
+oh_my_zsh_case_sensitive: false
+oh_my_zsh_hyphen_insensitive: false
+oh_my_zsh_disable_auto_update: false
+oh_my_zsh_update_zsh_days: 13
+oh_my_zsh_disable_ls_colors: false
+oh_my_zsh_disable_auto_title: false
+oh_my_zsh_enable_correction: false
+oh_my_zsh_completion_waiting_dots: false
+oh_my_zsh_disable_untracked_files_dirty: false
+oh_my_zsh_hist_stamps: "mm/dd/yyyy"
+oh_my_zsh_zsh_custom: "$ZSH/custom"
+oh_my_zsh_plugins: []

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -21,4 +21,7 @@
         # Only create `.zshrc` for user 'lorem'; item.settings will be
         # appended to `.zshrc` for the user 'ipsum'.
         oh_my_zsh_zshrc_create: "{{ (item.name == 'lorem') | ternary(true, false) }}"
+        oh_my_zsh_plugins:
+          - "autojump"
+          - "git"
       with_items: "{{ users }}"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -45,6 +45,7 @@ def test_zshrc_create(host, name):
 
     assert f.exists and f.is_file
     assert "export ZSH=/home/{0}/.oh-my-zsh".format(name) in f.content_string
+    assert "plugins=(autojump git)" in f.content_string
 
 
 @pytest.mark.parametrize("name", [

--- a/templates/zshrc.zsh-template.j2
+++ b/templates/zshrc.zsh-template.j2
@@ -9,51 +9,51 @@ export ZSH=/{{ zsh_user_home_dir }}/{{ zsh_user.name }}/{{ oh_my_zsh_install_dir
 # Set name of the theme to load. Optionally, if you set this to "random"
 # it'll load a random theme each time that oh-my-zsh is loaded.
 # See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
-ZSH_THEME="{{ oh_my_zsh_zshrc.zsh_theme }}"
+ZSH_THEME="{{ oh_my_zsh_zsh_theme }}"
 
 # Uncomment the following line to use case-sensitive completion.
-CASE_SENSITIVE="{{ oh_my_zsh_zshrc.case_sensitive }}"
+CASE_SENSITIVE="{{ oh_my_zsh_case_sensitive }}"
 
 # Uncomment the following line to use hyphen-insensitive completion. Case
 # sensitive completion must be off. _ and - will be interchangeable.
-HYPHEN_INSENSITIVE="{{ oh_my_zsh_zshrc.hyphen_insensitive }}"
+HYPHEN_INSENSITIVE="{{ oh_my_zsh_hyphen_insensitive }}"
 
 # Uncomment the following line to disable bi-weekly auto-update checks.
-DISABLE_AUTO_UPDATE="{{ oh_my_zsh_zshrc.disable_auto_update }}"
+DISABLE_AUTO_UPDATE="{{ oh_my_zsh_disable_auto_update }}"
 
 # Uncomment the following line to change how often to auto-update (in days).
-export UPDATE_ZSH_DAYS={{ oh_my_zsh_zshrc.update_zsh_days }}
+export UPDATE_ZSH_DAYS={{ oh_my_zsh_update_zsh_days }}
 
 # Uncomment the following line to disable colors in ls.
-DISABLE_LS_COLORS="{{ oh_my_zsh_zshrc.disable_ls_colors }}"
+DISABLE_LS_COLORS="{{ oh_my_zsh_disable_ls_colors }}"
 
 # Uncomment the following line to disable auto-setting terminal title.
-DISABLE_AUTO_TITLE="{{ oh_my_zsh_zshrc.disable_auto_title }}"
+DISABLE_AUTO_TITLE="{{ oh_my_zsh_disable_auto_title }}"
 
 # Uncomment the following line to enable command auto-correction.
-ENABLE_CORRECTION="{{ oh_my_zsh_zshrc.enable_correction }}"
+ENABLE_CORRECTION="{{ oh_my_zsh_enable_correction }}"
 
 # Uncomment the following line to display red dots whilst waiting for completion.
-COMPLETION_WAITING_DOTS="{{ oh_my_zsh_zshrc.completion_waiting_dots }}"
+COMPLETION_WAITING_DOTS="{{ oh_my_zsh_completion_waiting_dots }}"
 
 # Uncomment the following line if you want to disable marking untracked files
 # under VCS as dirty. This makes repository status check for large repositories
 # much, much faster.
-DISABLE_UNTRACKED_FILES_DIRTY="{{ oh_my_zsh_zshrc.disable_untracked_files_dirty }}"
+DISABLE_UNTRACKED_FILES_DIRTY="{{ oh_my_zsh_disable_untracked_files_dirty }}"
 
 # Uncomment the following line if you want to change the command execution time
 # stamp shown in the history command output.
 # The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-HIST_STAMPS="{{ oh_my_zsh_zshrc.hist_stamps }}"
+HIST_STAMPS="{{ oh_my_zsh_hist_stamps }}"
 
 # Would you like to use another custom folder than $ZSH/custom?
-ZSH_CUSTOM={{ oh_my_zsh_zshrc.zsh_custom }}
+ZSH_CUSTOM={{ oh_my_zsh_zsh_custom }}
 
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=({{ oh_my_zsh_zshrc.plugins | join(" ") }})
+plugins=({{ oh_my_zsh_plugins | join(" ") }})
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
Eliminates list var, replaces with individual vars--there aren't so many that there was any real advantage to the list.