### PR TITLE
Use FQCN for task names to avoid linter warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Make sure zsh is installed and set to the user's default shell.
 - name: "OMZ | include zsh.yml tasks."
-  include_tasks: "zsh.yml"
+  ansible.builtin.include_tasks: "zsh.yml"
   tags:
     - "zsh"
     - "configure"
@@ -9,7 +9,7 @@
 
 # Install oh-my-zsh.
 - name: "OMZ | include oh-my-zsh.yml tasks."
-  include_tasks: oh-my-zsh-install.yml
+  ansible.builtin.include_tasks: oh-my-zsh-install.yml
   tags:
     - "oh-my-zsh"
     - "install"
@@ -18,7 +18,7 @@
 # Configure oh-my-zsh with a custom .zshrc template if omz_zshrc_create
 # is set to 'true'.
 - name: "OMZ | include oh-my-zsh-zshrc.yml tasks."
-  include_tasks: oh-my-zsh-zshrc.yml
+  ansible.builtin.include_tasks: oh-my-zsh-zshrc.yml
   tags:
     - "oh-my-zsh"
     - "configure"
@@ -27,7 +27,7 @@
 # Finally, add exports etc to .zshrc /last/ (i.e. so they get added to whaterver
 # .zshrc exists.
 - name: "OMZ | include zsh-zshrc.yml tasks."
-  include_tasks: zsh-zshrc.yml
+  ansible.builtin.include_tasks: zsh-zshrc.yml
   tags:
     - "zsh"
     - "configure"

--- a/tasks/oh-my-zsh-install.yml
+++ b/tasks/oh-my-zsh-install.yml
@@ -1,10 +1,10 @@
 ---
 - name: "OMZ | establish install location."
-  set_fact:
+  ansible.builtin.set_fact:
     omz_install_path: "/{{ omz_user_home_dir }}/{{ omz_user.name }}/{{ omz_install_directory }}"
 
 - name: "OMZ | clone Oh My ZSH repo for user."
-  git:
+  ansible.builtin.git:
     repo: "{{ omz_git_repository }}"
     dest: "{{ omz_install_path }}"
     update: "true"
@@ -12,8 +12,8 @@
     version: "master"
   register: "omz_clone"
 
-- name: "OMZ | set ownership on newly cloned repository."
-  file:
+- name: "OMZ | set ownership on newly cloned repository." # noqa: no-handler
+  ansible.builtin.file:
     path: "{{ omz_install_path }}"
     owner: "{{ omz_user.name }}"
     group: "{{ omz_user.group }}"

--- a/tasks/oh-my-zsh-zshrc.yml
+++ b/tasks/oh-my-zsh-zshrc.yml
@@ -1,14 +1,15 @@
 ---
 - name: "OMZ | derive user .zshrc path."
-  set_fact:
+  ansible.builtin.set_fact:
     omz_user_zshrc_path: "/{{ omz_user_home_dir }}/{{ omz_user.name }}/.zshrc"
 
 - name: "OMZ | template .zshrc into place if required."
-  template:
+  ansible.builtin.template:
     src: "{{ omz_zshrc_template }}"
     dest: "{{ omz_user_zshrc_path }}"
     owner: "{{ omz_user.name }}"
     group: "{{ omz_user.group }}"
     backup: "{{ omz_zshrc_backup }}"
     force: "{{ omz_zshrc_force }}"
+    mode: "0644"
   when: "omz_zshrc_create"

--- a/tasks/zsh-zshrc.yml
+++ b/tasks/zsh-zshrc.yml
@@ -1,8 +1,8 @@
 ---
 # Note that we assume this file exists! lineinfile will fail if the file is
 # not present.
-- name: "OMZ | export vars to .zshrc if required."
-  blockinfile:
+- name: "OMZ | export vars to .zshrc if required." # noqa: empty-string-compare
+  ansible.builtin.blockinfile:
     dest: "{{ omz_user_zshrc_path }}"
     block: "{{ omz_user.settings }}"
     backup: "{{ omz_zshrc_backup }}"
@@ -10,5 +10,5 @@
     - "omz_user.settings is defined"
     # Don't flag this line for checking if the value is empty--checking for an
     # empty value makes perfect sense.
-    - "omz_user.settings != ''"  # noqa 602
+    - "omz_user.settings != ''"
     - "not omz_zshrc_create"

--- a/tasks/zsh.yml
+++ b/tasks/zsh.yml
@@ -1,12 +1,12 @@
 ---
 - name: "OMZ | establish home directory."
-  set_fact:
+  ansible.builtin.set_fact:
     omz_user_home_dir: "{{ (ansible_system == 'Darwin') | ternary('Users', 'home') }}"
 
 - name: "OMZ | ensure zsh is installed."
   block:
     - name: "OMZ | install zsh for Linux."
-      package:
+      ansible.builtin.package:
         name: "zsh"
         state: "present"
       when:
@@ -14,19 +14,19 @@
         - "omz_install_zsh"
 
     - name: "OMZ | install zsh for macOS."
-      homebrew:
+      community.general.homebrew:
         name: "zsh"
         state: "present"
       when:
         - "ansible_system == 'Darwin'"
         - "omz_install_zsh"
 
-- name: "OMZ | get zsh installed path."
-  shell: "command -v zsh"
+- name: "OMZ | get zsh installed path." # noqa: command-instead-of-shell
+  ansible.builtin.shell: "command -v zsh"
   register: omz_zsh_installed_path
   changed_when: "false"
 
 - name: "OMZ | get user shell to zsh."
-  user:
+  ansible.builtin.user:
     name: "{{ omz_user.name }}"
     shell: "{{ omz_zsh_installed_path.stdout }}"


### PR DESCRIPTION
Awesome work with the role! I've updated the role to use FQCNs to avoid linter warning.